### PR TITLE
expose login-frontend on port 80

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     image: ghcr.io/gamify-it/login-frontend:latest
     restart: always
     expose:
-      - "8000"
+      - "80"
 
   overworld:
     container_name: overworld

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -10,7 +10,7 @@ server {
     proxy_set_header   X-Forwarded-Host $server_name;
 
     location / {
-        proxy_pass      http://login-frontend:8000/;
+        proxy_pass      http://login-frontend/;
     }
 
     location /api/login/ {


### PR DESCRIPTION
Since Login-frontend has now a new release is the expose port now 80.