### PR TITLE
fix keycloak port handling

### DIFF
--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -81,8 +81,7 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
-      KC_HOSTNAME: goulburn.informatik.uni-stuttgart.de
-      KC_HOSTNAME_PORT: 8443
+      KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak
       KC_HTTP_PORT: 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,8 +80,7 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
-      KC_HOSTNAME: goulburn.informatik.uni-stuttgart.de
-      KC_HOSTNAME_PORT: 443
+      KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak
       KC_HTTP_PORT: 80

--- a/nginx/conf.d-test/default.conf
+++ b/nginx/conf.d-test/default.conf
@@ -16,6 +16,7 @@ server {
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $server_name;
     proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_set_header   X-Forwarded-Port $server_port;
 
     location / {
         proxy_pass      http://landing-page-test/;

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -16,6 +16,7 @@ server {
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $server_name;
     proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_set_header   X-Forwarded-Port $server_port;
 
     location / {
         proxy_pass      http://landing-page/;


### PR DESCRIPTION
The problem with the admin interface was that keycloak doen't handle the `KC_HOSTNAME_PORT` as expected. It works for login requests but the admin console breaks if the environment variable is set.

I added the `X-Forwarded-Port` so keycloak knows the ports from the request and added `KC_HOSTNAME_STRICT: false` because nginx only redirects requests with the correct hostname .


Closes Gamify-IT/issues#252