### PR TITLE
add restart always to keycloak containers

### DIFF
--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -70,6 +70,7 @@ services:
     expose:
       - "80"
     image: quay.io/keycloak/keycloak:19.0
+    restart: always
     command:
       - "start"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
     expose:
       - "80"
     image: quay.io/keycloak/keycloak:19.0
+    restart: always
     command:
       - "start"
     environment:


### PR DESCRIPTION
add `restart: always`, so that the containers restart automatically after a reboot of the host machine