### PR TITLE
add Towecrush

### DIFF
--- a/goulburn/dev/docker-compose.yaml
+++ b/goulburn/dev/docker-compose.yaml
@@ -40,13 +40,13 @@ services:
       - POSTGRES_PASSWORD=postgres
 
   crosswordpuzzle-db:
-    container_name: crossword-db-dev
+    container_name: crosswordpuzzle-db-dev
     image: postgres:14-alpine
     restart: always
     expose:
       - "5432"
     volumes:
-      - ./data/crossword-db:/var/lib/postgresql/data
+      - ./data/crosswordpuzzle-db:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres

--- a/goulburn/dev/nginx/conf.d/default.conf
+++ b/goulburn/dev/nginx/conf.d/default.conf
@@ -27,8 +27,8 @@ server {
     set $regex_game regex-game-dev;
     set $bugfinder bugfinder-dev;
     set $finitequiz finitequiz-dev;
-    set $lecturer_interface lecturer-interface-dev;
     set $towercrush towercrush-dev;
+    set $lecturer_interface lecturer-interface-dev;
     set $third_party_license_notice third-party-license-notice-dev;
 
     proxy_buffer_size          128k;

--- a/goulburn/prod/docker-compose.yaml
+++ b/goulburn/prod/docker-compose.yaml
@@ -40,13 +40,13 @@ services:
       - POSTGRES_PASSWORD=postgres
 
   crosswordpuzzle-db:
-    container_name: crossword-db
+    container_name: crosswordpuzzle-db
     image: postgres:14-alpine
     restart: always
     expose:
       - "5432"
     volumes:
-      - ./data/crossword-db:/var/lib/postgresql/data
+      - ./data/crosswordpuzzle-db:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
@@ -71,6 +71,18 @@ services:
       - "5432"
     volumes:
     - ./data/bugfinder-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
+  towercrush-db:
+    container_name: towercrush-db
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+    - ./data/towercrush-db:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
@@ -181,6 +193,22 @@ services:
       - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
       - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
+  towercrush-backend:
+    container_name:   towercrush-backend
+    image: ghcr.io/gamify-it/towercrush-backend:latest
+    restart: always
+    expose:
+      - "80"
+    depends_on:
+      - bugfinder-db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://towercrush-db:5432/postgres
+      - OVERWORLD_URL=http://overworld-backend/api/v1
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
+
   #frontends
   landing-page:
     container_name: landing-page
@@ -234,6 +262,13 @@ services:
   lecturer-interface:
     container_name: lecturer-interface
     image: ghcr.io/gamify-it/lecturer-interface:latest
+    restart: always
+    expose:
+      - "80"
+
+  towercrush:
+    container_name: towercrush
+    image: ghcr.io/gamify-it/towercrush:latest
     restart: always
     expose:
       - "80"

--- a/goulburn/prod/nginx/conf.d/default.conf
+++ b/goulburn/prod/nginx/conf.d/default.conf
@@ -19,6 +19,7 @@ server {
     set $crosswordpuzzle_backend crosswordpuzzle-backend;
     set $finitequiz_backend finitequiz-backend;
     set $bugfinder_backend bugfinder-backend;
+    set $towercrush_backend towercrush-backend;
     set $overworld overworld;
     set $git_card_game git-card-game;
     set $chickenshock chickenshock;
@@ -26,6 +27,7 @@ server {
     set $regex_game regex-game;
     set $bugfinder bugfinder;
     set $finitequiz finitequiz;
+    set $towercrush towercrush;
     set $lecturer_interface lecturer-interface;
     set $third_party_license_notice third-party-license-notice;
 
@@ -74,6 +76,13 @@ server {
         proxy_pass      http://$bugfinder_backend;
     }
 
+    location /minigames/towercrush/api/ {
+        rewrite    ^/minigames/towercrush/(.*)$ /$1 break;
+        proxy_pass      http://$towercrush_backend;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+    }
+
     location /overworld/ {
         rewrite    ^/overworld/(.*)$ /$1 break;
         proxy_pass      http://$overworld;
@@ -112,6 +121,11 @@ server {
     location /lecturer-interface/ {
         rewrite    ^/lecturer-interface/(.*)$ /$1 break;
         proxy_pass      http://$lecturer_interface;
+    }
+
+    location /minigames/towercrush/ {
+        rewrite    ^/minigames/towercrush/(.*)$ /$1 break;
+        proxy_pass      http://$towercrush;
     }
 
     location /third-party-license-notice/ {

--- a/goulburn/test/docker-compose.yaml
+++ b/goulburn/test/docker-compose.yaml
@@ -40,13 +40,13 @@ services:
       - POSTGRES_PASSWORD=postgres
 
   crosswordpuzzle-db:
-    container_name: crossword-db-test
+    container_name: crosswordpuzzle-db-test
     image: postgres:14-alpine
     restart: always
     expose:
       - "5432"
     volumes:
-      - ./data/crossword-db:/var/lib/postgresql/data
+      - ./data/crosswordpuzzle-db:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
@@ -71,6 +71,18 @@ services:
       - "5432"
     volumes:
     - ./data/bugfinder-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
+  towercrush-db:
+    container_name: towercrush-db-test
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+    - ./data/towercrush-db:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
@@ -181,6 +193,22 @@ services:
       - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
       - KEYCLOAK_URL=http://keycloak-test/keycloak/realms/Gamify-IT
 
+  towercrush-backend:
+    container_name:   towercrush-backend-test
+    image: ghcr.io/gamify-it/towercrush-backend:main
+    restart: always
+    expose:
+      - "80"
+    depends_on:
+      - bugfinder-db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://towercrush-db-test:5432/postgres
+      - OVERWORLD_URL=http://overworld-backend-test/api/v1
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak-test/keycloak/realms/Gamify-IT
+
 
   #frontends
   landing-page:
@@ -242,6 +270,13 @@ services:
   finitequiz:
     container_name: finitequiz-test
     image: ghcr.io/gamify-it/finitequiz:main
+    restart: always
+    expose:
+      - "80"
+
+  towercrush:
+    container_name: towercrush-test
+    image: ghcr.io/gamify-it/towercrush:main
     restart: always
     expose:
       - "80"

--- a/goulburn/test/nginx/conf.d/default.conf
+++ b/goulburn/test/nginx/conf.d/default.conf
@@ -19,6 +19,7 @@ server {
     set $crosswordpuzzle_backend crosswordpuzzle-backend-test;
     set $finitequiz_backend finitequiz-backend-test;
     set $bugfinder_backend bugfinder-backend-test;
+    set $towercrush_backend towercrush-backend-test;
     set $overworld overworld-test;
     set $git_card_game git-card-game-test;
     set $chickenshock chickenshock-test;
@@ -26,6 +27,7 @@ server {
     set $regex_game regex-game-test;
     set $bugfinder bugfinder-test;
     set $finitequiz finitequiz-test;
+    set $towercrush towercrush-test;
     set $lecturer_interface lecturer-interface-test;
     set $third_party_license_notice third-party-license-notice-test;
 
@@ -73,6 +75,13 @@ server {
         proxy_pass      http://$bugfinder_backend;
     }
 
+    location /minigames/towercrush/api/ {
+        rewrite    ^/minigames/towercrush/(.*)$ /$1 break;
+        proxy_pass      http://$towercrush_backend;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+    }
+
     location /overworld/ {
         rewrite    ^/overworld/(.*)$ /$1 break;
         proxy_pass      http://$overworld;
@@ -106,6 +115,11 @@ server {
     location /minigames/finitequiz/ {
         rewrite    ^/minigames/finitequiz/(.*)$ /$1 break;
         proxy_pass      http://$finitequiz;
+    }
+
+    location /minigames/towercrush/ {
+        rewrite    ^/minigames/towercrush/(.*)$ /$1 break;
+        proxy_pass      http://$towercrush;
     }
 
     location /lecturer-interface/ {

--- a/template/docker-compose.yaml
+++ b/template/docker-compose.yaml
@@ -40,13 +40,13 @@ services:
       - POSTGRES_PASSWORD=postgres
 
   crosswordpuzzle-db:
-    container_name: crossword-db
+    container_name: crosswordpuzzle-db
     image: postgres:14-alpine
     restart: always
     expose:
       - "5432"
     volumes:
-      - ./data/crossword-db:/var/lib/postgresql/data
+      - ./data/crosswordpuzzle-db:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
@@ -71,6 +71,18 @@ services:
       - "5432"
     volumes:
     - ./data/bugfinder-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
+  towercrush-db:
+    container_name: towercrush-db
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+    - ./data/towercrush-db:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
@@ -181,6 +193,22 @@ services:
       - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
       - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
+  towercrush-backend:
+    container_name:   towercrush-backend
+    image: ghcr.io/gamify-it/towercrush-backend:latest
+    restart: always
+    expose:
+      - "80"
+    depends_on:
+      - bugfinder-db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://towercrush-db:5432/postgres
+      - OVERWORLD_URL=http://overworld-backend/api/v1
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
+
 
   #frontends
   landing-page:
@@ -242,6 +270,13 @@ services:
   finitequiz:
     container_name: finitequiz
     image: ghcr.io/gamify-it/finitequiz:latest
+    restart: always
+    expose:
+      - "80"
+
+  towercrush:
+    container_name: towercrush
+    image: ghcr.io/gamify-it/towercrush:latest
     restart: always
     expose:
       - "80"

--- a/template/nginx/conf.d/default.conf
+++ b/template/nginx/conf.d/default.conf
@@ -19,6 +19,7 @@ server {
     set $crosswordpuzzle_backend crosswordpuzzle-backend;
     set $finitequiz_backend finitequiz-backend;
     set $bugfinder_backend bugfinder-backend;
+    set $towercrush_backend towercrush-backend;
     set $overworld overworld;
     set $git_card_game git-card-game;
     set $chickenshock chickenshock;
@@ -26,6 +27,7 @@ server {
     set $regex_game regex-game;
     set $bugfinder bugfinder;
     set $finitequiz finitequiz;
+    set $towercrush towercrush;
     set $lecturer_interface lecturer-interface;
     set $third_party_license_notice third-party-license-notice;
 
@@ -73,6 +75,13 @@ server {
         proxy_pass      http://$bugfinder_backend;
     }
 
+    location /minigames/towercrush/api/ {
+        rewrite    ^/minigames/towercrush/(.*)$ /$1 break;
+        proxy_pass      http://$towercrush_backend;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+    }
+
     location /overworld/ {
         rewrite    ^/overworld/(.*)$ /$1 break;
         proxy_pass      http://$overworld;
@@ -106,6 +115,11 @@ server {
     location /minigames/finitequiz/ {
         rewrite    ^/minigames/finitequiz/(.*)$ /$1 break;
         proxy_pass      http://$finitequiz;
+    }
+
+    location /minigames/towercrush/ {
+        rewrite    ^/minigames/towercrush/(.*)$ /$1 break;
+        proxy_pass      http://$towercrush;
     }
 
     location /lecturer-interface/ {

--- a/testing/docker-compose-latest.yaml
+++ b/testing/docker-compose-latest.yaml
@@ -83,6 +83,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  towercrush-db:
+    container_name: towercrush-db
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+    - ./data/towercrush-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   #backends
   keycloak:
     container_name: keycloak
@@ -195,6 +207,22 @@ services:
       - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
       - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
+  towercrush-backend:
+    container_name:   towercrush-backend
+    image: ghcr.io/gamify-it/towercrush-backend:latest
+    restart: always
+    expose:
+      - "80"
+    depends_on:
+      - bugfinder-db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://towercrush-db:5432/postgres
+      - OVERWORLD_URL=http://overworld-backend/api/v1
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
+
 
   #frontends
   landing-page:
@@ -265,6 +293,13 @@ services:
     container_name: finitequiz
     image: ghcr.io/gamify-it/finitequiz:latest
     pull_policy: always
+    restart: always
+    expose:
+      - "80"
+
+  towercrush:
+    container_name: towercrush
+    image: ghcr.io/gamify-it/towercrush:latest
     restart: always
     expose:
       - "80"

--- a/testing/docker-compose-main.yaml
+++ b/testing/docker-compose-main.yaml
@@ -83,6 +83,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  towercrush-db:
+    container_name: towercrush-db
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+    - ./data/towercrush-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   #backends
   keycloak:
     container_name: keycloak
@@ -195,6 +207,22 @@ services:
       - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
       - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
+  towercrush-backend:
+    container_name:   towercrush-backend
+    image: ghcr.io/gamify-it/towercrush-backend:main
+    restart: always
+    expose:
+      - "80"
+    depends_on:
+      - bugfinder-db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://towercrush-db:5432/postgres
+      - OVERWORLD_URL=http://overworld-backend/api/v1
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
+
 
   #frontends
   landing-page:
@@ -265,6 +293,13 @@ services:
     container_name: finitequiz
     image: ghcr.io/gamify-it/finitequiz:main
     pull_policy: always
+    restart: always
+    expose:
+      - "80"
+
+  towercrush:
+    container_name: towercrush
+    image: ghcr.io/gamify-it/towercrush:main
     restart: always
     expose:
       - "80"

--- a/testing/nginx/conf.d/default.conf
+++ b/testing/nginx/conf.d/default.conf
@@ -10,6 +10,7 @@ server {
     set $crosswordpuzzle_backend crosswordpuzzle-backend;
     set $finitequiz_backend finitequiz-backend;
     set $bugfinder_backend bugfinder-backend;
+    set $towercrush_backend towercrush-backend;
     set $overworld overworld;
     set $git_card_game git-card-game;
     set $chickenshock chickenshock;
@@ -17,6 +18,7 @@ server {
     set $regex_game regex-game;
     set $bugfinder bugfinder;
     set $finitequiz finitequiz;
+    set $towercrush towercrush;
     set $lecturer_interface lecturer-interface;
     set $third_party_license_notice third-party-license-notice;
 
@@ -64,6 +66,13 @@ server {
         proxy_pass      http://$bugfinder-backend;
     }
 
+    location /minigames/towercrush/api/ {
+        rewrite    ^/minigames/towercrush/(.*)$ /$1 break;
+        proxy_pass      http://$towercrush_backend;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+    }
+
     location /overworld/ {
         rewrite    ^/overworld/(.*)$ /$1 break;
         proxy_pass      http://$overworld;
@@ -97,6 +106,11 @@ server {
     location /minigames/finitequiz/ {
         rewrite    ^/minigames/finitequiz/(.*)$ /$1 break;
         proxy_pass      http://$finitequiz;
+    }
+
+    location /minigames/towercrush/ {
+        rewrite    ^/minigames/towercrush/(.*)$ /$1 break;
+        proxy_pass      http://$towercrush;
     }
 
     location /lecturer-interface/ {


### PR DESCRIPTION
Part of Gamify-IT/issues#448

This PR adds Towercrush to the docker-compose files.

Also change crossword-db to crosswordpuzzle-db to be more consistent.

Please test at least one docker compose file.