### PR TITLE
add memory and fileserver

### DIFF
--- a/goulburn/dev/.env
+++ b/goulburn/dev/.env
@@ -1,3 +1,4 @@
 url=https://goulburn.informatik.uni-stuttgart.de:9443
 http_port=9000
 https_port=9443
+fileserver_keycloak_client_secret=

--- a/goulburn/dev/docker-compose.yaml
+++ b/goulburn/dev/docker-compose.yaml
@@ -15,6 +15,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  fileserver-db:
+    container_name: fileserver-db-dev
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+      - ./data/fileserver-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   overworld-db:
     container_name: overworld-db-dev
     image: postgres:14-alpine
@@ -105,10 +117,29 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
+      KC_HOSTNAME_URL: http://${url}/keycloak
       KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak
       KC_HTTP_PORT: 80
+
+  fileserver:
+    container_name: fileserver
+    image: ghcr.io/gamify-it/sharry-fileserver:development
+    restart: always
+    expose:
+      - "80"
+    volumes:
+      - ./data/fileserver-storage:/storage
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://fileserver-db:5432/postgres
+      - BASE_URL=${url}
+      - KEYCLOAK_CLIENT_ID=fileserver
+      - KEYCLOAK_CLIENT_SECRET=${fileserver_keycloak_client_secret}
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
   overworld-backend:
     container_name:   overworld-backend-dev

--- a/goulburn/dev/docker-compose.yaml
+++ b/goulburn/dev/docker-compose.yaml
@@ -87,6 +87,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  memory-db:
+    container_name: memory-db-dev
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+    - ./data/memory-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   towercrush-db:
     container_name: towercrush-db-dev
     image: postgres:14-alpine
@@ -224,6 +236,22 @@ services:
       - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
       - KEYCLOAK_URL=http://keycloak-dev/keycloak/realms/Gamify-IT
 
+  memory-backend:
+    container_name:   memory-backend-dev
+    image: ghcr.io/gamify-it/memory-backend:development
+    restart: always
+    expose:
+      - "80"
+    depends_on:
+      - memory-db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://memory-db-dev:5432/postgres
+      - OVERWORLD_URL=http://overworld-backend-dev/api/v1
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak-dev/keycloak/realms/Gamify-IT
+
   towercrush-backend:
     container_name:   towercrush-backend-dev
     image: ghcr.io/gamify-it/towercrush-backend:development
@@ -287,6 +315,14 @@ services:
   bugfinder:
     container_name: bugfinder-dev
     image: ghcr.io/gamify-it/bugfinder:development
+    restart: always
+    expose:
+      - "80"
+
+  memory:
+    container_name: memory-dev
+    image: ghcr.io/gamify-it/memory:development
+    pull_policy: always
     restart: always
     expose:
       - "80"

--- a/goulburn/dev/docker-compose.yaml
+++ b/goulburn/dev/docker-compose.yaml
@@ -129,7 +129,7 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
-      KC_HOSTNAME_URL: http://${url}/keycloak
+      KC_HOSTNAME_URL: ${url}/keycloak
       KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak

--- a/goulburn/dev/nginx/conf.d/default.conf
+++ b/goulburn/dev/nginx/conf.d/default.conf
@@ -14,6 +14,7 @@ server {
 
     set $landing_page landing-page-dev;
     set $keycloak keycloak-dev;
+    set $fileserver fileserver-dev;
     set $overworld_backend overworld-backend-dev;
     set $chickenshock_backend chickenshock-backend-dev;
     set $crosswordpuzzle_backend crosswordpuzzle-backend-dev;
@@ -48,6 +49,16 @@ server {
 
     location /keycloak/ {
         proxy_pass      http://$keycloak;
+    }
+
+    location /fileserver/ {
+        return 301 /app/;
+    }
+    location /app {
+        proxy_pass      http://fileserver/app;
+    }
+    location /api {
+        proxy_pass      http://fileserver/api;
     }
 
     location /overworld/api/ {

--- a/goulburn/dev/nginx/conf.d/default.conf
+++ b/goulburn/dev/nginx/conf.d/default.conf
@@ -57,10 +57,10 @@ server {
         return 301 /app/;
     }
     location /app/ {
-        proxy_pass      http://fileserver/app/;
+        proxy_pass      http://$fileserver/app/;
     }
     location /api/ {
-        proxy_pass      http://fileserver/api/;
+        proxy_pass      http://$fileserver/api/;
     }
 
     location /overworld/api/ {

--- a/goulburn/dev/nginx/conf.d/default.conf
+++ b/goulburn/dev/nginx/conf.d/default.conf
@@ -56,11 +56,11 @@ server {
     location /fileserver/ {
         return 301 /app/;
     }
-    location /app {
-        proxy_pass      http://fileserver/app;
+    location /app/ {
+        proxy_pass      http://fileserver/app/;
     }
-    location /api {
-        proxy_pass      http://fileserver/api;
+    location /api/ {
+        proxy_pass      http://fileserver/api/;
     }
 
     location /overworld/api/ {

--- a/goulburn/dev/nginx/conf.d/default.conf
+++ b/goulburn/dev/nginx/conf.d/default.conf
@@ -20,6 +20,7 @@ server {
     set $crosswordpuzzle_backend crosswordpuzzle-backend-dev;
     set $finitequiz_backend finitequiz-backend-dev;
     set $bugfinder_backend bugfinder-backend-dev;
+    set $memory_backend memory-backend-dev;
     set $towercrush_backend towercrush-backend-dev;
     set $overworld overworld-dev;
     set $git_card_game git-card-game-dev;
@@ -27,6 +28,7 @@ server {
     set $crosswordpuzzle crosswordpuzzle-dev;
     set $regex_game regex-game-dev;
     set $bugfinder bugfinder-dev;
+    set $memory memory-dev;
     set $finitequiz finitequiz-dev;
     set $towercrush towercrush-dev;
     set $lecturer_interface lecturer-interface-dev;
@@ -86,6 +88,11 @@ server {
         proxy_pass      http://$bugfinder_backend;
     }
 
+    location /minigames/memory/api/ {
+        rewrite    ^/minigames/memory/(.*)$ /$1 break;
+        proxy_pass      http://$memory_backend;
+    }
+
     location /minigames/towercrush/api/ {
         rewrite    ^/minigames/towercrush/(.*)$ /$1 break;
         proxy_pass      http://$towercrush_backend;
@@ -121,6 +128,11 @@ server {
     location /minigames/bugfinder/ {
         rewrite    ^/minigames/bugfinder/(.*)$ /$1 break;
         proxy_pass      http://$bugfinder;
+    }
+
+    location /minigames/memory/ {
+        rewrite    ^/minigames/memory/(.*)$ /$1 break;
+        proxy_pass      http://$memory;
     }
 
     location /minigames/finitequiz/ {

--- a/goulburn/prod/.env
+++ b/goulburn/prod/.env
@@ -1,3 +1,4 @@
 url=https://goulburn.informatik.uni-stuttgart.de
 http_port=80
 https_port=443
+fileserver_keycloak_client_secret=

--- a/goulburn/prod/docker-compose.yaml
+++ b/goulburn/prod/docker-compose.yaml
@@ -15,6 +15,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  fileserver-db:
+    container_name: fileserver-db
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+      - ./data/fileserver-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   overworld-db:
     container_name: overworld-db
     image: postgres:14-alpine
@@ -105,10 +117,29 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
+      KC_HOSTNAME_URL: http://${url}/keycloak
       KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak
       KC_HTTP_PORT: 80
+
+  fileserver:
+    container_name: fileserver
+    image: ghcr.io/gamify-it/sharry-fileserver:latest
+    restart: always
+    expose:
+      - "80"
+    volumes:
+      - ./data/fileserver-storage:/storage
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://fileserver-db:5432/postgres
+      - BASE_URL=${url}
+      - KEYCLOAK_CLIENT_ID=fileserver
+      - KEYCLOAK_CLIENT_SECRET=${fileserver_keycloak_client_secret}
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
   overworld-backend:
     container_name:   overworld-backend

--- a/goulburn/prod/docker-compose.yaml
+++ b/goulburn/prod/docker-compose.yaml
@@ -129,7 +129,7 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
-      KC_HOSTNAME_URL: http://${url}/keycloak
+      KC_HOSTNAME_URL: ${url}/keycloak
       KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak

--- a/goulburn/prod/docker-compose.yaml
+++ b/goulburn/prod/docker-compose.yaml
@@ -87,6 +87,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  memory-db:
+    container_name: memory-db
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+    - ./data/memory-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   towercrush-db:
     container_name: towercrush-db
     image: postgres:14-alpine
@@ -224,6 +236,22 @@ services:
       - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
       - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
+  memory-backend:
+    container_name:   memory-backend
+    image: ghcr.io/gamify-it/memory-backend:latest
+    restart: always
+    expose:
+      - "80"
+    depends_on:
+      - memory-db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://memory-db:5432/postgres
+      - OVERWORLD_URL=http://overworld-backend/api/v1
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
+
   towercrush-backend:
     container_name:   towercrush-backend
     image: ghcr.io/gamify-it/towercrush-backend:latest
@@ -286,6 +314,14 @@ services:
   bugfinder:
     container_name: bugfinder
     image: ghcr.io/gamify-it/bugfinder:latest
+    restart: always
+    expose:
+      - "80"
+
+  memory:
+    container_name: memory
+    image: ghcr.io/gamify-it/memory:latest
+    pull_policy: always
     restart: always
     expose:
       - "80"

--- a/goulburn/prod/nginx/conf.d/default.conf
+++ b/goulburn/prod/nginx/conf.d/default.conf
@@ -57,11 +57,11 @@ server {
     location /fileserver/ {
         return 301 /app/;
     }
-    location /app {
-        proxy_pass      http://fileserver/app;
+    location /app/ {
+        proxy_pass      http://fileserver/app/;
     }
-    location /api {
-        proxy_pass      http://fileserver/api;
+    location /api/ {
+        proxy_pass      http://fileserver/api/;
     }
 
     location /overworld/api/ {

--- a/goulburn/prod/nginx/conf.d/default.conf
+++ b/goulburn/prod/nginx/conf.d/default.conf
@@ -20,6 +20,7 @@ server {
     set $crosswordpuzzle_backend crosswordpuzzle-backend;
     set $finitequiz_backend finitequiz-backend;
     set $bugfinder_backend bugfinder-backend;
+    set $memory_backend memory-backend;
     set $towercrush_backend towercrush-backend;
     set $overworld overworld;
     set $git_card_game git-card-game;
@@ -27,6 +28,7 @@ server {
     set $crosswordpuzzle crosswordpuzzle;
     set $regex_game regex-game;
     set $bugfinder bugfinder;
+    set $memory memory;
     set $finitequiz finitequiz;
     set $towercrush towercrush;
     set $lecturer_interface lecturer-interface;
@@ -87,6 +89,11 @@ server {
         proxy_pass      http://$bugfinder_backend;
     }
 
+    location /minigames/memory/api/ {
+        rewrite    ^/minigames/memory/(.*)$ /$1 break;
+        proxy_pass      http://$memory_backend;
+    }
+
     location /minigames/towercrush/api/ {
         rewrite    ^/minigames/towercrush/(.*)$ /$1 break;
         proxy_pass      http://$towercrush_backend;
@@ -122,6 +129,11 @@ server {
     location /minigames/bugfinder/ {
         rewrite    ^/minigames/bugfinder/(.*)$ /$1 break;
         proxy_pass      http://$bugfinder;
+    }
+
+    location /minigames/memory/ {
+        rewrite    ^/minigames/memory/(.*)$ /$1 break;
+        proxy_pass      http://$memory;
     }
 
     location /minigames/finitequiz/ {

--- a/goulburn/prod/nginx/conf.d/default.conf
+++ b/goulburn/prod/nginx/conf.d/default.conf
@@ -14,6 +14,7 @@ server {
 
     set $landing_page landing-page;
     set $keycloak keycloak;
+    set $fileserver fileserver;
     set $overworld_backend overworld-backend;
     set $chickenshock_backend chickenshock-backend;
     set $crosswordpuzzle_backend crosswordpuzzle-backend;
@@ -49,6 +50,16 @@ server {
 
     location /keycloak/ {
         proxy_pass      http://$keycloak;
+    }
+
+    location /fileserver/ {
+        return 301 /app/;
+    }
+    location /app {
+        proxy_pass      http://fileserver/app;
+    }
+    location /api {
+        proxy_pass      http://fileserver/api;
     }
 
     location /overworld/api/ {

--- a/goulburn/prod/nginx/conf.d/default.conf
+++ b/goulburn/prod/nginx/conf.d/default.conf
@@ -58,10 +58,10 @@ server {
         return 301 /app/;
     }
     location /app/ {
-        proxy_pass      http://fileserver/app/;
+        proxy_pass      http://$fileserver/app/;
     }
     location /api/ {
-        proxy_pass      http://fileserver/api/;
+        proxy_pass      http://$fileserver/api/;
     }
 
     location /overworld/api/ {

--- a/goulburn/test/.env
+++ b/goulburn/test/.env
@@ -1,3 +1,4 @@
 url=https://goulburn.informatik.uni-stuttgart.de:8443
 http_port=8000
 https_port=8443
+fileserver_keycloak_client_secret=test-client-secret

--- a/goulburn/test/docker-compose.yaml
+++ b/goulburn/test/docker-compose.yaml
@@ -87,6 +87,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  memory-db:
+    container_name: memory-db-test
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+    - ./data/memory-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   towercrush-db:
     container_name: towercrush-db-test
     image: postgres:14-alpine
@@ -224,6 +236,22 @@ services:
       - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
       - KEYCLOAK_URL=http://keycloak-test/keycloak/realms/Gamify-IT
 
+  memory-backend:
+    container_name:   memory-backend-test
+    image: ghcr.io/gamify-it/memory-backend:main
+    restart: always
+    expose:
+      - "80"
+    depends_on:
+      - memory-db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://memory-db-test:5432/postgres
+      - OVERWORLD_URL=http://overworld-backend-test/api/v1
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak-test/keycloak/realms/Gamify-IT
+
   towercrush-backend:
     container_name:   towercrush-backend-test
     image: ghcr.io/gamify-it/towercrush-backend:main
@@ -287,6 +315,14 @@ services:
   bugfinder:
     container_name: bugfinder-test
     image: ghcr.io/gamify-it/bugfinder:main
+    restart: always
+    expose:
+      - "80"
+
+  memory:
+    container_name: memory-test
+    image: ghcr.io/gamify-it/memory:main
+    pull_policy: always
     restart: always
     expose:
       - "80"

--- a/goulburn/test/docker-compose.yaml
+++ b/goulburn/test/docker-compose.yaml
@@ -129,7 +129,7 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
-      KC_HOSTNAME_URL: http://${url}/keycloak
+      KC_HOSTNAME_URL: ${url}/keycloak
       KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak

--- a/goulburn/test/docker-compose.yaml
+++ b/goulburn/test/docker-compose.yaml
@@ -15,6 +15,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  fileserver-db:
+    container_name: fileserver-db-test
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+      - ./data/fileserver-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   overworld-db:
     container_name: overworld-db-test
     image: postgres:14-alpine
@@ -105,10 +117,29 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
+      KC_HOSTNAME_URL: http://${url}/keycloak
       KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak
       KC_HTTP_PORT: 80
+
+  fileserver:
+    container_name: fileserver
+    image: ghcr.io/gamify-it/sharry-fileserver:main
+    restart: always
+    expose:
+      - "80"
+    volumes:
+      - ./data/fileserver-storage:/storage
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://fileserver-db:5432/postgres
+      - BASE_URL=${url}
+      - KEYCLOAK_CLIENT_ID=fileserver
+      - KEYCLOAK_CLIENT_SECRET=${fileserver_keycloak_client_secret}
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
   overworld-backend:
     container_name:   overworld-backend-test

--- a/goulburn/test/nginx/conf.d/default.conf
+++ b/goulburn/test/nginx/conf.d/default.conf
@@ -57,10 +57,10 @@ server {
         return 301 /app/;
     }
     location /app/ {
-        proxy_pass      http://fileserver/app/;
+        proxy_pass      http://$fileserver/app/;
     }
     location /api/ {
-        proxy_pass      http://fileserver/api/;
+        proxy_pass      http://$fileserver/api/;
     }
 
     location /overworld/api/ {

--- a/goulburn/test/nginx/conf.d/default.conf
+++ b/goulburn/test/nginx/conf.d/default.conf
@@ -14,6 +14,7 @@ server {
 
     set $landing_page landing-page-test;
     set $keycloak keycloak-test;
+    set $fileserver fileserver-test;
     set $overworld_backend overworld-backend-test;
     set $chickenshock_backend chickenshock-backend-test;
     set $crosswordpuzzle_backend crosswordpuzzle-backend-test;
@@ -48,6 +49,16 @@ server {
 
     location /keycloak/ {
         proxy_pass      http://$keycloak;
+    }
+
+    location /fileserver/ {
+        return 301 /app/;
+    }
+    location /app {
+        proxy_pass      http://fileserver/app;
+    }
+    location /api {
+        proxy_pass      http://fileserver/api;
     }
 
     location /overworld/api/ {

--- a/goulburn/test/nginx/conf.d/default.conf
+++ b/goulburn/test/nginx/conf.d/default.conf
@@ -56,11 +56,11 @@ server {
     location /fileserver/ {
         return 301 /app/;
     }
-    location /app {
-        proxy_pass      http://fileserver/app;
+    location /app/ {
+        proxy_pass      http://fileserver/app/;
     }
-    location /api {
-        proxy_pass      http://fileserver/api;
+    location /api/ {
+        proxy_pass      http://fileserver/api/;
     }
 
     location /overworld/api/ {

--- a/goulburn/test/nginx/conf.d/default.conf
+++ b/goulburn/test/nginx/conf.d/default.conf
@@ -20,6 +20,7 @@ server {
     set $crosswordpuzzle_backend crosswordpuzzle-backend-test;
     set $finitequiz_backend finitequiz-backend-test;
     set $bugfinder_backend bugfinder-backend-test;
+    set $memory_backend memory-backend-test;
     set $towercrush_backend towercrush-backend-test;
     set $overworld overworld-test;
     set $git_card_game git-card-game-test;
@@ -27,6 +28,7 @@ server {
     set $crosswordpuzzle crosswordpuzzle-test;
     set $regex_game regex-game-test;
     set $bugfinder bugfinder-test;
+    set $memory memory-test;
     set $finitequiz finitequiz-test;
     set $towercrush towercrush-test;
     set $lecturer_interface lecturer-interface-test;
@@ -86,6 +88,11 @@ server {
         proxy_pass      http://$bugfinder_backend;
     }
 
+    location /minigames/memory/api/ {
+        rewrite    ^/minigames/memory/(.*)$ /$1 break;
+        proxy_pass      http://$memory_backend;
+    }
+
     location /minigames/towercrush/api/ {
         rewrite    ^/minigames/towercrush/(.*)$ /$1 break;
         proxy_pass      http://$towercrush_backend;
@@ -121,6 +128,11 @@ server {
     location /minigames/bugfinder/ {
         rewrite    ^/minigames/bugfinder/(.*)$ /$1 break;
         proxy_pass      http://$bugfinder;
+    }
+
+    location /minigames/memory/ {
+        rewrite    ^/minigames/memory/(.*)$ /$1 break;
+        proxy_pass      http://$memory;
     }
 
     location /minigames/finitequiz/ {

--- a/template/.env
+++ b/template/.env
@@ -1,3 +1,4 @@
 url=https://my-domain
 http_port=80
 https_port=443
+fileserver_keycloak_client_secret=

--- a/template/docker-compose.yaml
+++ b/template/docker-compose.yaml
@@ -15,6 +15,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  fileserver-db:
+    container_name: fileserver-db
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+      - ./data/fileserver-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   overworld-db:
     container_name: overworld-db
     image: postgres:14-alpine
@@ -105,10 +117,29 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
+      KC_HOSTNAME_URL: http://${url}/keycloak
       KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak
       KC_HTTP_PORT: 80
+
+  fileserver:
+    container_name: fileserver
+    image: ghcr.io/gamify-it/sharry-fileserver:latest
+    restart: always
+    expose:
+      - "80"
+    volumes:
+      - ./data/fileserver-storage:/storage
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://fileserver-db:5432/postgres
+      - BASE_URL=${url}
+      - KEYCLOAK_CLIENT_ID=fileserver
+      - KEYCLOAK_CLIENT_SECRET=${fileserver_keycloak_client_secret}
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
   overworld-backend:
     container_name:   overworld-backend

--- a/template/docker-compose.yaml
+++ b/template/docker-compose.yaml
@@ -129,7 +129,7 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
-      KC_HOSTNAME_URL: http://${url}/keycloak
+      KC_HOSTNAME_URL: ${url}/keycloak
       KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak

--- a/template/docker-compose.yaml
+++ b/template/docker-compose.yaml
@@ -87,6 +87,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  memory-db:
+    container_name: memory-db
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+    - ./data/memory-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   towercrush-db:
     container_name: towercrush-db
     image: postgres:14-alpine
@@ -224,6 +236,22 @@ services:
       - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
       - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
+  memory-backend:
+    container_name:   memory-backend
+    image: ghcr.io/gamify-it/memory-backend:latest
+    restart: always
+    expose:
+      - "80"
+    depends_on:
+      - memory-db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://memory-db:5432/postgres
+      - OVERWORLD_URL=http://overworld-backend/api/v1
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
+
   towercrush-backend:
     container_name:   towercrush-backend
     image: ghcr.io/gamify-it/towercrush-backend:latest
@@ -287,6 +315,14 @@ services:
   bugfinder:
     container_name: bugfinder
     image: ghcr.io/gamify-it/bugfinder:latest
+    restart: always
+    expose:
+      - "80"
+
+  memory:
+    container_name: memory
+    image: ghcr.io/gamify-it/memory:latest
+    pull_policy: always
     restart: always
     expose:
       - "80"

--- a/template/nginx/conf.d/default.conf
+++ b/template/nginx/conf.d/default.conf
@@ -20,6 +20,7 @@ server {
     set $crosswordpuzzle_backend crosswordpuzzle-backend;
     set $finitequiz_backend finitequiz-backend;
     set $bugfinder_backend bugfinder-backend;
+    set $memory_backend memory-backend;
     set $towercrush_backend towercrush-backend;
     set $overworld overworld;
     set $git_card_game git-card-game;
@@ -27,6 +28,7 @@ server {
     set $crosswordpuzzle crosswordpuzzle;
     set $regex_game regex-game;
     set $bugfinder bugfinder;
+    set $memory memory;
     set $finitequiz finitequiz;
     set $towercrush towercrush;
     set $lecturer_interface lecturer-interface;
@@ -86,6 +88,11 @@ server {
         proxy_pass      http://$bugfinder_backend;
     }
 
+    location /minigames/memory/api/ {
+        rewrite    ^/minigames/memory/(.*)$ /$1 break;
+        proxy_pass      http://$memory_backend;
+    }
+
     location /minigames/towercrush/api/ {
         rewrite    ^/minigames/towercrush/(.*)$ /$1 break;
         proxy_pass      http://$towercrush_backend;
@@ -121,6 +128,11 @@ server {
     location /minigames/bugfinder/ {
         rewrite    ^/minigames/bugfinder/(.*)$ /$1 break;
         proxy_pass      http://$bugfinder;
+    }
+
+    location /minigames/memory/ {
+        rewrite    ^/minigames/memory/(.*)$ /$1 break;
+        proxy_pass      http://$memory;
     }
 
     location /minigames/finitequiz/ {

--- a/template/nginx/conf.d/default.conf
+++ b/template/nginx/conf.d/default.conf
@@ -57,10 +57,10 @@ server {
         return 301 /app/;
     }
     location /app/ {
-        proxy_pass      http://fileserver/app/;
+        proxy_pass      http://$fileserver/app/;
     }
     location /api/ {
-        proxy_pass      http://fileserver/api/;
+        proxy_pass      http://$fileserver/api/;
     }
 
     location /overworld/api/ {

--- a/template/nginx/conf.d/default.conf
+++ b/template/nginx/conf.d/default.conf
@@ -14,6 +14,7 @@ server {
 
     set $landing_page landing-page;
     set $keycloak keycloak;
+    set $fileserver fileserver;
     set $overworld_backend overworld-backend;
     set $chickenshock_backend chickenshock-backend;
     set $crosswordpuzzle_backend crosswordpuzzle-backend;
@@ -48,6 +49,16 @@ server {
 
     location /keycloak/ {
         proxy_pass      http://$keycloak;
+    }
+
+    location /fileserver/ {
+        return 301 /app/;
+    }
+    location /app {
+        proxy_pass      http://fileserver/app;
+    }
+    location /api {
+        proxy_pass      http://fileserver/api;
     }
 
     location /overworld/api/ {

--- a/template/nginx/conf.d/default.conf
+++ b/template/nginx/conf.d/default.conf
@@ -56,11 +56,11 @@ server {
     location /fileserver/ {
         return 301 /app/;
     }
-    location /app {
-        proxy_pass      http://fileserver/app;
+    location /app/ {
+        proxy_pass      http://fileserver/app/;
     }
-    location /api {
-        proxy_pass      http://fileserver/api;
+    location /api/ {
+        proxy_pass      http://fileserver/api/;
     }
 
     location /overworld/api/ {

--- a/testing/.env
+++ b/testing/.env
@@ -1,2 +1,3 @@
 url=http://localhost
 http_port=80
+fileserver_keycloak_client_secret=

--- a/testing/.env
+++ b/testing/.env
@@ -1,3 +1,3 @@
 url=http://localhost
 http_port=80
-fileserver_keycloak_client_secret=
+fileserver_keycloak_client_secret=test-client-secret

--- a/testing/docker-compose-latest.yaml
+++ b/testing/docker-compose-latest.yaml
@@ -28,6 +28,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  fileserver-db:
+    container_name: fileserver-db
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+      - ./data/fileserver-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   overworld-db:
     container_name: overworld-db
     image: postgres:14-alpine
@@ -114,10 +126,29 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
+      KC_HOSTNAME_URL: http://${url}/keycloak
       KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak
       KC_HTTP_PORT: 80
+
+  fileserver:
+    container_name: fileserver
+    image: ghcr.io/gamify-it/sharry-fileserver:latest
+    restart: always
+    expose:
+      - "80"
+    volumes:
+      - ./data/fileserver-storage:/storage
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://fileserver-db:5432/postgres
+      - BASE_URL=${url}
+      - KEYCLOAK_CLIENT_ID=fileserver
+      - KEYCLOAK_CLIENT_SECRET=${fileserver_keycloak_client_secret}
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
   overworld-backend:
     container_name:   overworld-backend

--- a/testing/docker-compose-latest.yaml
+++ b/testing/docker-compose-latest.yaml
@@ -95,6 +95,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  memory-db:
+    container_name: memory-db
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+    - ./data/memory-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   towercrush-db:
     container_name: towercrush-db
     image: postgres:14-alpine
@@ -238,6 +250,22 @@ services:
       - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
       - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
+  memory-backend:
+    container_name:   memory-backend
+    image: ghcr.io/gamify-it/memory-backend:latest
+    restart: always
+    expose:
+      - "80"
+    depends_on:
+      - memory-db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://memory-db:5432/postgres
+      - OVERWORLD_URL=http://overworld-backend/api/v1
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
+
   towercrush-backend:
     container_name:   towercrush-backend
     image: ghcr.io/gamify-it/towercrush-backend:latest
@@ -307,6 +335,14 @@ services:
   bugfinder:
     container_name: bugfinder
     image: ghcr.io/gamify-it/bugfinder:latest
+    pull_policy: always
+    restart: always
+    expose:
+      - "80"
+
+  memory:
+    container_name: memory
+    image: ghcr.io/gamify-it/memory:latest
     pull_policy: always
     restart: always
     expose:

--- a/testing/docker-compose-latest.yaml
+++ b/testing/docker-compose-latest.yaml
@@ -138,7 +138,7 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
-      KC_HOSTNAME_URL: http://${url}/keycloak
+      KC_HOSTNAME_URL: ${url}/keycloak
       KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak

--- a/testing/docker-compose-main.yaml
+++ b/testing/docker-compose-main.yaml
@@ -28,6 +28,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  fileserver-db:
+    container_name: fileserver-db
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+      - ./data/fileserver-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   overworld-db:
     container_name: overworld-db
     image: postgres:14-alpine
@@ -114,10 +126,29 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
+      KC_HOSTNAME_URL: http://${url}/keycloak
       KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak
       KC_HTTP_PORT: 80
+
+  fileserver:
+    container_name: fileserver
+    image: ghcr.io/gamify-it/sharry-fileserver:main
+    restart: always
+    expose:
+      - "80"
+    volumes:
+      - ./data/fileserver-storage:/storage
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://fileserver-db:5432/postgres
+      - BASE_URL=${url}
+      - KEYCLOAK_CLIENT_ID=fileserver
+      - KEYCLOAK_CLIENT_SECRET=${fileserver_keycloak_client_secret}
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
   overworld-backend:
     container_name:   overworld-backend

--- a/testing/docker-compose-main.yaml
+++ b/testing/docker-compose-main.yaml
@@ -138,7 +138,7 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
-      KC_HOSTNAME_URL: http://${url}/keycloak
+      KC_HOSTNAME_URL: ${url}/keycloak
       KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak

--- a/testing/docker-compose-main.yaml
+++ b/testing/docker-compose-main.yaml
@@ -95,6 +95,18 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
+  memory-db:
+    container_name: memory-db
+    image: postgres:14-alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+    - ./data/memory-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
   towercrush-db:
     container_name: towercrush-db
     image: postgres:14-alpine
@@ -238,6 +250,22 @@ services:
       - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
       - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
+  memory-backend:
+    container_name:   memory-backend
+    image: ghcr.io/gamify-it/memory-backend:main
+    restart: always
+    expose:
+      - "80"
+    depends_on:
+      - memory-db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_URL=postgresql://memory-db:5432/postgres
+      - OVERWORLD_URL=http://overworld-backend/api/v1
+      - KEYCLOAK_ISSUER=${url}/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
+
   towercrush-backend:
     container_name:   towercrush-backend
     image: ghcr.io/gamify-it/towercrush-backend:main
@@ -307,6 +335,14 @@ services:
   bugfinder:
     container_name: bugfinder
     image: ghcr.io/gamify-it/bugfinder:main
+    pull_policy: always
+    restart: always
+    expose:
+      - "80"
+
+  memory:
+    container_name: memory
+    image: ghcr.io/gamify-it/memory:main
     pull_policy: always
     restart: always
     expose:

--- a/testing/nginx/conf.d/default.conf
+++ b/testing/nginx/conf.d/default.conf
@@ -11,6 +11,7 @@ server {
     set $crosswordpuzzle_backend crosswordpuzzle-backend;
     set $finitequiz_backend finitequiz-backend;
     set $bugfinder_backend bugfinder-backend;
+    set $memory_backend memory-backend;
     set $towercrush_backend towercrush-backend;
     set $overworld overworld;
     set $git_card_game git-card-game;
@@ -18,6 +19,7 @@ server {
     set $crosswordpuzzle crosswordpuzzle;
     set $regex_game regex-game;
     set $bugfinder bugfinder;
+    set $memory memory;
     set $finitequiz finitequiz;
     set $towercrush towercrush;
     set $lecturer_interface lecturer-interface;
@@ -77,6 +79,11 @@ server {
         proxy_pass      http://$bugfinder-backend;
     }
 
+    location /minigames/memory/api/ {
+        rewrite    ^/minigames/memory/(.*)$ /$1 break;
+        proxy_pass      http://$memory_backend;
+    }
+
     location /minigames/towercrush/api/ {
         rewrite    ^/minigames/towercrush/(.*)$ /$1 break;
         proxy_pass      http://$towercrush_backend;
@@ -112,6 +119,11 @@ server {
     location /minigames/bugfinder/ {
         rewrite    ^/minigames/bugfinder/(.*)$ /$1 break;
         proxy_pass      http://$bugfinder;
+    }
+
+    location /minigames/memory/ {
+        rewrite    ^/minigames/memory/(.*)$ /$1 break;
+        proxy_pass      http://$memory;
     }
 
     location /minigames/finitequiz/ {

--- a/testing/nginx/conf.d/default.conf
+++ b/testing/nginx/conf.d/default.conf
@@ -48,10 +48,10 @@ server {
         return 301 /app/;
     }
     location /app/ {
-        proxy_pass      http://fileserver/app/;
+        proxy_pass      http://$fileserver/app/;
     }
     location /api/ {
-        proxy_pass      http://fileserver/api/;
+        proxy_pass      http://$fileserver/api/;
     }
 
     location /overworld/api/ {

--- a/testing/nginx/conf.d/default.conf
+++ b/testing/nginx/conf.d/default.conf
@@ -47,11 +47,11 @@ server {
     location /fileserver/ {
         return 301 /app/;
     }
-    location /app {
-        proxy_pass      http://fileserver/app;
+    location /app/ {
+        proxy_pass      http://fileserver/app/;
     }
-    location /api {
-        proxy_pass      http://fileserver/api;
+    location /api/ {
+        proxy_pass      http://fileserver/api/;
     }
 
     location /overworld/api/ {

--- a/testing/nginx/conf.d/default.conf
+++ b/testing/nginx/conf.d/default.conf
@@ -5,6 +5,7 @@ server {
 
     set $landing_page landing-page;
     set $keycloak keycloak;
+    set $fileserver fileserver;
     set $overworld_backend overworld-backend;
     set $chickenshock_backend chickenshock-backend;
     set $crosswordpuzzle_backend crosswordpuzzle-backend;
@@ -39,6 +40,16 @@ server {
 
     location /keycloak/ {
         proxy_pass      http://$keycloak;
+    }
+
+    location /fileserver/ {
+        return 301 /app/;
+    }
+    location /app {
+        proxy_pass      http://fileserver/app;
+    }
+    location /api {
+        proxy_pass      http://fileserver/api;
     }
 
     location /overworld/api/ {


### PR DESCRIPTION
Add the memory minigame and the Fileserver.

Part of Gamify-IT/issues#469 and Gamify-IT/issues#480

You can tag the current development images with the needed tag for testing the `docker-compose-main.yaml` in the testing folder with the following commands:
```
docker pull ghcr.io/gamify-it/memory-backend:development && docker tag ghcr.io/gamify-it/memory-backend:development ghcr.io/gamify-it/memory-backend:main
```
```
docker pull ghcr.io/gamify-it/sharry-fileserver:development && docker tag ghcr.io/gamify-it/sharry-fileserver:development ghcr.io/gamify-it/sharry-fileserver:main
```
```
docker pull ghcr.io/gamify-it/test-data:feature-update-keycloak-sharry && docker tag ghcr.io/gamify-it/test-data:feature-update-keycloak-sharry ghcr.io/gamify-it/test-data:latest
```

And then run it with:
```
docker compose -f docker-compose-main.yaml up --pull missing
```